### PR TITLE
Fix missing memory header

### DIFF
--- a/bfloat16.cc
+++ b/bfloat16.cc
@@ -34,6 +34,7 @@ limitations under the License.
 #include <fenv.h>
 #include "numpy/arrayobject.h"
 #include "numpy/ufuncobject.h"
+#include <memory>
 
 namespace greenwaves
 {


### PR DESCRIPTION
Compilation breaks on `unique_ptr` because the memory header was missing.