### PR TITLE
[Bugfix] Fix compilation error since python 3.11 and macOS

### DIFF
--- a/bfloat16.cc
+++ b/bfloat16.cc
@@ -26,6 +26,7 @@ limitations under the License.
 
 #include <Python.h>
 #include <cinttypes>
+#include <patchlevel.h>
 #include <vector>
 #ifdef DEBUG_CALLS
 #include <iostream>
@@ -1745,7 +1746,13 @@ namespace greenwaves
 		NPyBfloat16_ArrFuncs.argmax = NPyBfloat16_ArgMaxFunc;
 		NPyBfloat16_ArrFuncs.argmin = NPyBfloat16_ArgMinFunc;
 
+		// Py_TYPE has been deprecated since Python 3.9
+		#if PY_MINOR_VERSION < 9
 		Py_TYPE(&NPyBfloat16_Descr) = &PyArrayDescr_Type;
+		#else
+		Py_SET_TYPE(&NPyBfloat16_Descr, &PyArrayDescr_Type);
+		#endif
+
 		npy_bfloat16 = PyArray_RegisterDataType(&NPyBfloat16_Descr);
 		bfloat16_type_ptr = &bfloat16_type;
 		if (npy_bfloat16 < 0)

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,8 @@ class my_build_ext(build_ext):
 
 module1 = Extension(PACKAGE_NAME,
                     sources=['bfloat16.cc'],
-                    include_dirs=[np.get_include()])
+                    include_dirs=[np.get_include()],
+                    extra_compile_args=['-std=c++11'])
 
 setup(name=PACKAGE_NAME,
       version='1.1',


### PR DESCRIPTION
bfloat16 could not be built since Python 3.11, for Py_TYPE has been deprecated since Python 3.9, see PEP 674 and Common Object Structures docs for details. This issue was covered in #5. 
bfloat16 could not be built on macOS, because C++11 flag is not enabled by default in clang. This issue was covered in #7.